### PR TITLE
menu.jsp <spring:url> 사용

### DIFF
--- a/TeamProject/src/main/webapp/WEB-INF/views/common/menu.jsp
+++ b/TeamProject/src/main/webapp/WEB-INF/views/common/menu.jsp
@@ -1,8 +1,11 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
-<link rel="stylesheet" href="/resources/css/menu.css">
+<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<spring:url var="menuCss" value="/resources/css/menu.css" htmlEscape="true"/>
+<link rel="stylesheet" href="${menuCss}">
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-<script src="resources/js/menu.js"></script>
+<spring:url var="menuJs" value="/resources/js/menu.js" htmlEscape="true"/>
+<script src="${menuJs}"></script>
 <div class="container">
 	<div>
 		<a class="brand" href="homePage">EVERYWARE</a>
@@ -13,8 +16,8 @@
 			<li><a class="link" href="myPage">마이 페이지</a></li>
 			<li><a class="link" href="loginCheck/attendance/attendanceList">근태 관리</a></li>
 			<li><a class="link" href="organization">조직도</a></li>
-			<li><a class="link" href="/notices">공지사항</a></li>
-			<li><a class="link" href="/communities">자유게시판</a></li>
+			<li><a class="link" href="<spring:url value="/notices"/>">공지사항</a></li>
+			<li><a class="link" href="<spring:url value="/communities"/>">자유게시판</a></li>
 			<li><a class="link" href="FileBoard">자료함</a></li>
 			<li><a class="link" href="draftList">전자결재</a></li>
 			<li><span class="link"><a href="meetingRoom">회의실</a></span>


### PR DESCRIPTION
### 문제점
수정 페이지`notices/{id}/edit`에서 메뉴링크가 깨졌습니다.

### 원인
url 계층이 내려가면 상대 경로인 `resource/css/menu.css` 를 찾지 못합니다.

### 해결 방안
`<spring:url>` 태그 라이브러리는 **URL에 자동으로 Context Path 를 붙여주는 일**을 합니다.
`menu.jsp` 를 수정해서 경로와 상관없이 css, js 파일을 찾게 했습니다.

참조 자료
- [<c:url> 태그 사용법](https://offbyone.tistory.com/319)
- [스프링 JSP 태그 라이브러리](https://blog.naver.com/aservmz/222225560205)
- [[How to use <spring:url /> with an <a> tag?](https://stackoverflow.com/questions/5007210/how-to-use-springurl-with-an-a-tag)](https://stackoverflow.com/questions/5007210/how-to-use-springurl-with-an-a-tag)