### PR TITLE
utility.css, notice-details.jsp  수정

### DIFF
--- a/TeamProject/src/main/webapp/WEB-INF/views/notice/notice-details.jsp
+++ b/TeamProject/src/main/webapp/WEB-INF/views/notice/notice-details.jsp
@@ -27,7 +27,7 @@
 						<p id="title-mv" class="dib mv0 mr2 f5"><small class="title-mr">조회수</small>${notice.views}</p>
 					</div>
 					<div id="title-content">
-						<p class="measure lh-copy">${notice.content}</p>
+						${notice.content}
 					</div>
 					<c:if test="${not empty notice.files}">
 					<div class="flex flex-column">

--- a/TeamProject/src/main/webapp/resources/css/utility.css
+++ b/TeamProject/src/main/webapp/resources/css/utility.css
@@ -1934,7 +1934,7 @@ input[type="url"],
     margin-top: 24px;
     border: 2px solid #dededeab;
     width: 800px;
-    height: 300px;
+    min-height: 300px;
     border-radius: 11px;
     padding: 7px 15px 0px 20px;
     font-size: 14px;
@@ -1943,7 +1943,7 @@ input[type="url"],
 	margin-top: 24px;
     border: 2px solid #dededeab;
     width: 800px;
-    height: 230px;
+    min-height: 230px;
     border-radius: 11px;
     padding: 7px 15px 0px 20px;
     font-size: 14px;


### PR DESCRIPTION
utility.css
-컨텐츠의 양이 적을 때는 설정값으로 높이가 고정되고, 컨텐츠 양이 많을 때는 넘치지 않고 요소의 높이가 자연스럽게 늘어나도록 height -> min-height으로 수정 

notice-details.jsp
-공지사항 상세페이지 내용을 길게 작성했을 때 글이 잘리지 않도록 content 부분 수정